### PR TITLE
Handle JSON response from model

### DIFF
--- a/speak_to_data/application/__init__.py
+++ b/speak_to_data/application/__init__.py
@@ -7,6 +7,7 @@ from speak_to_data.application import (
     events,
     prepare_for_model,
     query_parser,
+response_parser,
     app_data_loader,
 )
 from speak_to_data.application.query_parser import QueryData
@@ -17,6 +18,7 @@ event_recorder = events.event_recorder
 parse_query = query_parser.parse_query
 QueryData = QueryData
 AppDataLoader = app_data_loader.AppDataLoader
+Response = response_parser.Response
 
 
 def initial_setup() -> None:

--- a/speak_to_data/application/response_parser.py
+++ b/speak_to_data/application/response_parser.py
@@ -1,0 +1,26 @@
+class Response:
+    def __init__(self, model_response: dict) -> None:
+        self.model_response = model_response
+
+    @property
+    def _has_answer(self) -> bool:
+        return "answer" in self.model_response
+
+    @property
+    def _has_error(self) -> bool:
+        return "error" in self.model_response
+
+    @property
+    def is_loading(self) -> bool:
+        return self._has_error and "currently loading" in self.model_response["error"]
+
+    @property
+    def table_empty(self) -> bool:
+        return self._has_error and "table is empty" in self.model_response["error"]
+
+    def __str__(self):
+        if self._has_error:
+            if self.table_empty:
+                return "No data was found based on the previous query."
+        else:
+            return self.model_response["answer"]

--- a/speak_to_data/presentation/app.py
+++ b/speak_to_data/presentation/app.py
@@ -1,6 +1,6 @@
-from speak_to_data import application, presentation
-
 from flask import Flask, redirect, render_template
+from speak_to_data import application, presentation
+import time
 
 application.initial_setup()
 
@@ -17,7 +17,13 @@ def index():
             request_object = application.generate_request_object(
                 valid_query_data, application.config.EVENT_RECORDS_PATH
             )
-            response = application.call_tapas_on_hf(request_object)
+            response_from_model = application.call_tapas_on_hf(request_object)
+            response_to_user = application.Response(response_from_model)
+            while response_to_user.is_loading:
+                time.sleep(3)
+                response_from_model = application.call_tapas_on_hf(request_object)
+                response_to_user = application.Response(response_from_model)
+            response = str(response_to_user)
         else:
             # Let the user know to change their query
             response = valid_query_data.query_dates.warning

--- a/speak_to_data/presentation/forms/forms.py
+++ b/speak_to_data/presentation/forms/forms.py
@@ -1,7 +1,5 @@
-from speak_to_data import application
 from speak_to_data.presentation.forms import action_form, shared_fields
-from wtforms import RadioField, StringField
-from wtforms.validators import AnyOf
+from wtforms import StringField, IntegerField
 
 
 class QueryForm(action_form.ActionForm):
@@ -18,20 +16,7 @@ class SowForm(action_form.ActionForm):
 
 class MaintainForm(action_form.ActionForm):
     date = shared_fields.date
-    duration = RadioField(
-        validate_choice=False,
-        validators=[
-            AnyOf(
-                values=("1", "3", "6"),
-                message=f"Not a valid choice.\n{application.config.NOT_SAVED_WARNING}",
-            )
-        ],
-        choices=(
-            ("1", "Less than 30 minutes"),
-            ("3", "Between 30 and 90 minutes"),
-            ("6", "More than 90 minutes"),
-        ),
-    )
+    duration = IntegerField("Duration in minutes")
     location = shared_fields.location
     location_type = shared_fields.location_type
 

--- a/speak_to_data/tests/acceptance/test_record_events.py
+++ b/speak_to_data/tests/acceptance/test_record_events.py
@@ -40,6 +40,7 @@ class Test_REF1_DisplayFormFields(unittest.TestCase):
             "select_with_name_location_type": r"\<select[^\>]*name=\"location_type\"",
             "input_with_radio_attr": r"\<input[^\>]*type=\"radio\"",
             "input_with_text_attr": r"\<input[^\>]*type=\"text\"",
+            "input_with_number_attr": r"\<input[^\>]*type=\"number\"",
         }
 
         route_form_tests = (
@@ -67,7 +68,7 @@ class Test_REF1_DisplayFormFields(unittest.TestCase):
                 route="/maintain",
                 patterns=(
                     "input_with_date_attr",
-                    "input_with_radio_attr",
+                    "input_with_number_attr",
                     "select_with_name_location",
                     "select_with_name_location_type",
                 ),
@@ -303,6 +304,6 @@ class Test_REF4_InformUserDataNotSaved(unittest.TestCase):
         ):
             form = presentation.MaintainForm()
             form.validate()
-            expected = "Not a valid choice.\nYour data was not saved!"
+            expected = "Not a valid integer value."
             actual = form.errors["duration"][0]
             self.assertEqual(expected, actual)

--- a/speak_to_data/tests/developer/test_presentation.py
+++ b/speak_to_data/tests/developer/test_presentation.py
@@ -17,11 +17,16 @@ class TestFlaskForms(unittest.TestCase):
         return set((field.name, field.type) for field in form)
 
     def setUp(self):
-        context = presentation.flask_app.test_request_context()
+        app = presentation.flask_app
+        app.config["WTF_CSRF_ENABLED"] = False
+        context = app.test_request_context()
         with context:
             self.query_form_fields = self._get_form_fields(presentation.QueryForm())
             self.sow_form = presentation.SowForm()
             self.sow_form_fields = self._get_form_fields(self.sow_form)
+            self.maintain_form_fields = self._get_form_fields(
+                presentation.MaintainForm()
+            )
 
     def test_query_form(self):
         expected = {
@@ -39,6 +44,16 @@ class TestFlaskForms(unittest.TestCase):
             ("location_type", "SelectField"),
         }
         actual = self.sow_form_fields
+        self.assertEqual(expected, actual)
+
+    def test_maintenance_form(self):
+        expected = {
+            ("date", "DateField"),
+            ("duration", "IntegerField"),
+            ("location", "SelectField"),
+            ("location_type", "SelectField"),
+        }
+        actual = self.maintain_form_fields
         self.assertEqual(expected, actual)
 
     def test_givenFormInstance_whenAskedOwnType_thenReturnsTypeAsString(self):


### PR DESCRIPTION
Take action depending on the response from TaPas model:

- If model is waiting to start up, continue to try and only return once a valid response is received
- If model has an error, display the error
- If model has an answer, display the answer

Also change the "Duration" field (maintenance form) to integer instead of radio options