### PR TITLE
add maintenance duration as a valid query

### DIFF
--- a/speak_to_data/application/__init__.py
+++ b/speak_to_data/application/__init__.py
@@ -15,7 +15,6 @@ from speak_to_data import communication
 
 nlp = spacy.load("en_core_web_sm")
 event_recorder = events.event_recorder
-parse_query = query_parser.parse_query
 QueryData = QueryData
 AppDataLoader = app_data_loader.AppDataLoader
 Response = response_parser.Response

--- a/speak_to_data/application/config.py
+++ b/speak_to_data/application/config.py
@@ -47,5 +47,6 @@ ACTION_NAMES = {
 
 ACTIONS = set(communication.read_json(APP_DATA_PATH)["actions"])
 CROPS = set(communication.read_json(APP_DATA_PATH)["crops"])
+LOCATIONS = set(communication.read_json(APP_DATA_PATH)["locations"])
 
 NOT_SAVED_WARNING = "Your data was not saved!"

--- a/speak_to_data/application/prepare_for_model.py
+++ b/speak_to_data/application/prepare_for_model.py
@@ -7,24 +7,28 @@ def generate_model_ready_dataset(
     if not query_data or not query_data.columns:
         return dict()
 
-    crop: set[str] = query_data.crop
-    action: set[str] = query_data.action
-    start_date, end_date = query_data.query_dates.date_range
+    crops: set[str] = query_data.crops
+    actions: set[str] = query_data.actions
+    locations: set[str] = query_data.locations
+    start_date, end_date = query_data.parsed_date.date_range
 
-    filter_rows = [
-        row
-        for row in dataset
-        if row["crop"] in crop
-        and row["action"] in action
-        and start_date <= row["date"] <= end_date
-    ]
+    filtered = dataset
 
-    if not filter_rows:
+    if crops:
+        filtered = [row for row in filtered if row["crop"] in crops]
+    if actions:
+        filtered = [row for row in filtered if row["action"] in actions]
+    if locations:
+        filtered = [row for row in filtered if row["location"] in locations]
+    if start_date and end_date:
+        filtered = [row for row in filtered if start_date <= row["date"] <= end_date]
+
+    if not filtered:
         return dict()
 
     filter_columns = [
         {key: row[key] for key in row.keys() if key in query_data.columns}
-        for row in filter_rows
+        for row in filtered
     ]
 
     transform = _list_of_dicts_to_one_dict(filter_columns)

--- a/speak_to_data/tests/acceptance/test_insight_natural_language.py
+++ b/speak_to_data/tests/acceptance/test_insight_natural_language.py
@@ -1,0 +1,68 @@
+import datetime
+import unittest
+
+from speak_to_data import application
+from speak_to_data import communication
+
+
+class Test_INLF2_ExtractParameters(unittest.TestCase):
+    def test_givenHowManyHowMuchCrop_thenQueryDataHasCorrectSelection(self):
+        query = "How much cress did I sow last year?"
+        parameters = application.query_parser.QueryData(query)
+        for attr, val in (
+                ("columns", {"crop", "action", "quantity"}),
+                ("crops", {"cress"}),
+                ("actions", {"sow"}),
+                ("crux", "what is sum of quantity?"),
+        ):
+            with self.subTest(msg=f"Testing attr: {attr}"):
+                self.assertEqual(getattr(parameters, attr), val)
+        with self.subTest(msg="Testing attr: dates"):
+            expected = (datetime.date(2023, 1, 1), datetime.date(2023, 12, 31))
+            actual = parameters.parsed_date.date_range
+            self.assertEqual(expected, actual)
+
+    def test_givenHowMuchTimeOrMaint_thenQueryDataHasCorrectSelection(self):
+        query = "How much time to maintain beds in the kitchen?"
+        parameters = application.query_parser.QueryData(query)
+        for attr, val in (
+                ("columns", {"action", "duration", "location"}),
+                ("actions", {"maintain"}),
+                ("crux", "what is sum of duration?"),
+        ):
+            with self.subTest(msg=f"Testing attr: {attr}"):
+                self.assertEqual(getattr(parameters, attr), val)
+
+
+class Test_INLF4_GenerateFilteredTable(unittest.TestCase):
+    def setUp(self):
+        self.mock_data = communication.read_dataset(application.config.MOCK_DATA_SMALL)
+        self.sow_cress = application.query_parser.QueryData("How much cress did I sow last year?")
+        self.maintain_kitchen = application.query_parser.QueryData("How much time last year to maintain beds in the kitchen?")
+
+    def test_givenSowCress_thenProduceFilteredTable(self):
+        expected = {
+            "action": [
+                "sow",
+                "sow"
+            ],
+            "crop": [
+                "cress",
+                "cress"
+            ],
+            "quantity": [
+                "1sqft",
+                "2sqft"
+            ],
+        }
+        actual = application.prepare_for_model.generate_model_ready_dataset(self.mock_data, self.sow_cress)
+        self.assertEqual(expected, actual)
+
+    def test_givenMaintainKitchen_thenProduceFilteredTable(self):
+        expected = {
+            "action": ["maintain"],
+            "duration": ["30"],
+            "location": ["kitchen"]
+        }
+        actual = application.prepare_for_model.generate_model_ready_dataset(self.mock_data, self.maintain_kitchen)
+        self.assertEqual(expected, actual)

--- a/speak_to_data/tests/developer/test_communication.py
+++ b/speak_to_data/tests/developer/test_communication.py
@@ -6,13 +6,14 @@ import unittest
 
 
 # Create test files
-fieldnames = ["date", "action", "crop", "quantity", "location", "location_type"]
+fieldnames = ["date", "action", "crop", "quantity", "duration", "location", "location_type"]
 mock_data = [
     {
         "date": "2023-04-28",
         "action": "sow",
         "crop": "cress",
         "quantity": "1sqft",
+        "duration": "",
         "location": "kitchen",
         "location_type": "indoor-window-box",
     },
@@ -21,9 +22,28 @@ mock_data = [
         "action": "sow",
         "crop": "cress",
         "quantity": "2sqft",
+        "duration": "",
         "location": "kitchen",
         "location_type": "indoor-window-box",
     },
+    {
+        "date": "2023-05-02",
+        "action": "maintain",
+        "crop": "",
+        "quantity": "",
+        "duration": "30",
+        "location": "kitchen",
+        "location_type": "indoor-window-box",
+    },
+    {
+        "date": "2023-05-04",
+        "action": "maintain",
+        "crop": "",
+        "quantity": "",
+        "duration": "40",
+        "location": "east-hoop-house",
+        "location_type": "hoop-house-raised-bed",
+    }
 ]
 with open(application.config.MOCK_DATA_ONELINE, "w", newline="") as ol:
     w = csv.DictWriter(ol, fieldnames=fieldnames, dialect="unix")

--- a/speak_to_data/tests/integration/test_csvToTable.py
+++ b/speak_to_data/tests/integration/test_csvToTable.py
@@ -1,4 +1,3 @@
-import json
 from speak_to_data import application
 from speak_to_data.application import config, prepare_for_model, query_parser
 from speak_to_data.communication import read_dataset
@@ -7,7 +6,7 @@ import unittest
 
 class TestCsvReaderToTableGenerator(unittest.TestCase):
     def setUp(self):
-        self.query_data = query_parser.parse_query(
+        self.query_data = query_parser.QueryData(
             "How much cress did I sow last year?"
         )
 

--- a/speak_to_data/tests/test_data/oneline_mock_data.csv
+++ b/speak_to_data/tests/test_data/oneline_mock_data.csv
@@ -1,2 +1,2 @@
-"date","action","crop","quantity","location","location_type"
-"2023-04-28","sow","cress","1sqft","kitchen","indoor-window-box"
+"date","action","crop","quantity","duration","location","location_type"
+"2023-04-28","sow","cress","1sqft","","kitchen","indoor-window-box"

--- a/speak_to_data/tests/test_data/small_mock_data.csv
+++ b/speak_to_data/tests/test_data/small_mock_data.csv
@@ -1,3 +1,5 @@
-"date","action","crop","quantity","location","location_type"
-"2023-04-28","sow","cress","1sqft","kitchen","indoor-window-box"
-"2023-04-29","sow","cress","2sqft","kitchen","indoor-window-box"
+"date","action","crop","quantity","duration","location","location_type"
+"2023-04-28","sow","cress","1sqft","","kitchen","indoor-window-box"
+"2023-04-29","sow","cress","2sqft","","kitchen","indoor-window-box"
+"2023-05-02","maintain","","","30","kitchen","indoor-window-box"
+"2023-05-04","maintain","","","40","east-hoop-house","hoop-house-raised-bed"


### PR DESCRIPTION
Add tests (including some acceptance tests) plus code to accept queries like "How much maintenance was required in the kitchen last year" for any valid location, which returns a sum of the duration values.

As part of this effort, the query_parser module now exposes a QueryData class (not dataclass) that handles retrieval of parameters from a text query.