### PR TITLE
resolve mypy errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
-[tool.mypy]
-ignore_missing_imports = true
-
 [tool.poetry]
 name = "speak_to_data"
 version = "0.2.0"
@@ -21,6 +18,9 @@ spacy = "^3.7.4"
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.10.0"
 black = "^24.4.2"
+
+[tool.mypy]
+ignore_missing_imports = true
 
 [build-system]
 requires = ["poetry-core"]

--- a/speak_to_data/application/query_parser.py
+++ b/speak_to_data/application/query_parser.py
@@ -6,7 +6,7 @@ from speak_to_data import application
 
 class QueryData:
     def __init__(self, raw_query: str) -> None:
-        self.columns = set()
+        self.columns: set = set()
         self.docd_query: Doc = application.nlp(raw_query)
         self.crops: set[str] = self._retrieve_crops()
         self.actions: set[str] = self._retrieve_actions()


### PR DESCRIPTION
The `[tool.mypy]` section in pyproject.toml was not being recognised correctly. Moving it towards the bottom of the file helped. Added a type to a single variable that was missing it.